### PR TITLE
Improvements to summary page stats

### DIFF
--- a/cfg/cfg.d/z_irstats2.pl
+++ b/cfg/cfg.d/z_irstats2.pl
@@ -458,10 +458,12 @@ $c->{irstats2}->{report} = {
 		category => 'general',
 	},
 
+	summary_page => {
+		items => [ 
+		{ plugin => 'Google::Graph', datatype => 'downloads', range => '1y', options => { date_resolution => 'month', graph_type => 'column', title => 'Downloads per month over past year' } },
+		],
+	},
 };
-
-# must be enabled manually
-$c->{plugins}{"Screen::EPrint::Box::Stats"}{params}{disable} = 1;
 
 # Bazaar config
 
@@ -509,3 +511,4 @@ $c->{plugins}{"Stats::View::Table"}{params}{disable} = 0;
 
 $c->{plugins}{"Screen::IRStats2::Report"}{params}{disable} = 0;
 
+$c->{plugins}{"Screen::EPrint::Box::Stats"}{params}{disable} = 0;

--- a/cfg/cfg.d/z_irstats2.pl
+++ b/cfg/cfg.d/z_irstats2.pl
@@ -511,4 +511,9 @@ $c->{plugins}{"Stats::View::Table"}{params}{disable} = 0;
 
 $c->{plugins}{"Screen::IRStats2::Report"}{params}{disable} = 0;
 
-$c->{plugins}{"Screen::EPrint::Box::Stats"}{params}{disable} = 0;
+# Display download stats for an EPrints on it's summary page?
+# Confusingly, set this to '0' to make them appear, or 1 to not show them
+$c->{plugins}{"Screen::EPrint::Box::Stats"}{params}{disable} = 1;
+# Where on the summary page should they appear?
+# Valid options are 'summary_left', 'summary_right', 'summary_bottom', 'summary_top'.
+$c->{plugins}{"Screen::EPrint::Box::Stats"}{params}{appears}{place} = 'summary_bottom';

--- a/lib/lang/en/phrases/irstats2.xml
+++ b/lib/lang/en/phrases/irstats2.xml
@@ -322,7 +322,7 @@ document.observe("dom:loaded",function(){
 <epp:phrase id="Plugin/Screen/Public/Stats/Repository:title">Repository Statistics</epp:phrase>
 
 <!-- Summary Page -->
-<epp:phrase id="Plugin/Screen/EPrint/Box/Stats:title">Download Statistics</epp:phrase>
+<epp:phrase id="Plugin/Screen/EPrint/Box/Stats:title">Statistics</epp:phrase>
 
 <!-- objects -->
 

--- a/lib/plugins/EPrints/Plugin/Screen/EPrint/Box/Stats.pm
+++ b/lib/plugins/EPrints/Plugin/Screen/EPrint/Box/Stats.pm
@@ -4,6 +4,22 @@ our @ISA = ( 'EPrints::Plugin::Screen::EPrint::Box' );
 
 use strict;
 
+sub new
+{
+	my( $class, %params ) = @_;
+
+	my $self = $class->SUPER::new(%params);
+
+	$self->{appears} = [
+		{
+			place => "summary_bottom",
+			position => 1000,
+		},
+	];
+
+	return $self;
+}
+
 sub can_be_viewed
 {
         my( $self ) = @_;
@@ -24,11 +40,56 @@ sub has_value
 
 sub render
 {
-        my( $self ) = @_;
+        my( $self, $eprint, $report ) = @_;
 
-        return $self->{session}->html_phrase( 'lib/irstats2:embedded:summary_page:eprint:downloads',
-                        eprintid => $self->{session}->make_text( $self->{processor}->{eprint}->get_id )
-        );
+	$eprint = $self->{processor}->{eprint} unless defined $eprint;
+
+	$report = $self->param( 'report' ) || 'summary_page' unless $report;
+
+	my $repo = $self->{repository};
+
+	my $handler = $repo->plugin( 'Stats::Handler' );
+
+	my $context = $handler->context( {
+		irs2report => $report,
+		set_name => 'eprint',
+		set_value => $eprint->id,
+		datatype => 'downloads',
+	} );
+
+	my $conf = $repo->config( qw( irstats2 report ), $report );
+
+	my $frag = $repo->make_doc_fragment;
+
+	foreach my $item ( @{$conf->{items} || []} )
+	{
+		my $pluginid = delete $item->{plugin};
+		next unless( defined $pluginid );
+
+		next if $pluginid eq "ReportHeader";
+
+		my $options = delete $item->{options};
+		$options ||= {};
+
+		# each View plugin needs its own copy of the context (if a View plugin changed one parameter of the context, this would propagate across all View plugins)	
+		my $local_context = $context->clone();
+
+		# local context
+		my $done_any = 0;
+		foreach( keys %$item )
+		{
+			$local_context->{$_} = $item->{$_};
+			$done_any = 1;
+		}
+		$local_context->parse_context() if( $done_any );
+
+		my $plugin = $repo->plugin( "Stats::View::$pluginid", handler => $handler, options => $options, context => $local_context );
+		next unless( defined $plugin );	# an error / warning would be nice...
+		
+		$frag->appendChild( $plugin->render );
+	}
+
+	return $frag;
 }
 
 sub render_collapsed { 0 }


### PR DESCRIPTION
* Switch the summary page Box::Stats on by default - not sure why this is off by default?
* Use a report to control what appears in the Box::Stats instead of having to hand-roll the box content using a phrase - this makes it much easier to have several different graphs/tables appearing in the box for example