### PR TITLE
Show the item title in the report header when viewing a report for an individual item

### DIFF
--- a/lib/plugins/EPrints/Plugin/Stats/Sets.pm
+++ b/lib/plugins/EPrints/Plugin/Stats/Sets.pm
@@ -588,8 +588,11 @@ sub render_set
 	if( !defined $use_cache || $use_cache )
 	{
 		my $cache_value = $self->handler->get_rendered_set_value( $setname, $setvalue );
-		HTML::Entities::decode_entities( $cache_value );	# to be safe
-		return $session->make_text( $cache_value );
+		if( defined $cache_value )
+		{
+			HTML::Entities::decode_entities( $cache_value );	# to be safe
+			return $session->make_text( $cache_value );
+		}
 	}
 
 	my $render_fn = $self->get_property( $setname, "render_single_value" );


### PR DESCRIPTION
See #5 

The issue seems to be that irstats2 assumes eprint titles will be cached (along with other set 'names') - but this isn't the case and the cache miss is not caught.

Running process_stats does not cache eprint titles - perhaps because the "set of eprints" is not a real set in the same way that "the set of item types" or "the set of author names" appear to be be ie. there is no entry in the irstats2 sets definition for the "set of eprints" - so no caching for this "set" happens in Sets::populate_tables().

This patch detects a cache miss and falls back to the default set name rendering.

We could extend this further to insert the generated set name into the cache for next time.