### PR TITLE
Update github pages branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# irstats2
-IRstats2 Documentation site using Github-pages.
+# IRStats 2
+Documentation site using Github-pages.
 Access from https://eprints.github.io/irstats2/
 

--- a/README.md
+++ b/README.md
@@ -1,0 +1,4 @@
+# irstats2
+IRstats2 Documentation site using Github-pages.
+Access from https://eprints.github.io/irstats2/
+

--- a/changes.html
+++ b/changes.html
@@ -32,13 +32,11 @@
     <!-- MAIN CONTENT -->
     <div id="main_content_wrap" class="outer">
       <section id="main_content" class="inner">
-
+        <p><strong>Changes in 1.1, since 1.0.x</strong></p>
 <p>
-  Changes in 1.1, since 1.0.x<br><br>
-
   Updates:
   <ul>
-    <li>Feature: IP based robot filtering and default values.</li>
+    <li>Feature: IP based robot filtering and default values</li>
     <li>Feature: Adding an option to only show live items in the stats</li>
     <li>Enhancement: Avoid using experimental perl code.(i.e. ~~ )</li>
     <li>Enhancement: restructure to make epm deployment easier</li>
@@ -49,7 +47,8 @@
     <li>Bugfix: Stats::View::google::Graph lose first statistics #69</li>
     <li>Bugfix for Browser identification issue #66. Browser ID should be further improved</li>
   </ul>
-
+</p>
+<p>
   Merged pull requests:
   <ul>
     <li>Enhancement: %IGNORE_LIST of words (stopwords) are very few and only in "en"</li>
@@ -58,7 +57,6 @@
     <li>Bugfix: Avoid XSS vulnerability in some CGI output</li>
   </ul>
 </p>
-
       </section>
     </div>
 

--- a/changes.html
+++ b/changes.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html>
+
+  <head>
+    <meta charset='utf-8' />
+    <meta http-equiv="X-UA-Compatible" content="chrome=1" />
+    <meta name="description" content="IRStats2 : Statistical tools for EPrints" />
+
+    <link rel="stylesheet" type="text/css" media="screen" href="stylesheets/stylesheet.css">
+
+    <title>IRStats2</title>
+  </head>
+
+  <body>
+
+    <!-- HEADER -->
+    <div id="header_wrap" class="outer">
+        <header class="inner">
+          <a id="forkme_banner" href="https://github.com/eprints/irstats2">View on GitHub</a>
+
+          <h1 id="project_title">IRStats2</h1>
+          <h2 id="project_tagline">Statistical tools for EPrints</h2>
+            <section id="topmenu">
+              <a href="./install.html">Installation</a>
+              <a href="./config.html">Configuration</a>
+              <a href="./api.html">API</a>
+            </section>
+
+        </header>
+    </div>
+
+    <!-- MAIN CONTENT -->
+    <div id="main_content_wrap" class="outer">
+      <section id="main_content" class="inner">
+
+<p>
+  Changes in 1.1, since 1.0.x<br><br>
+
+  Updates:
+  <ul>
+    <li>Feature: IP based robot filtering and default values.</li>
+    <li>Feature: Adding an option to only show live items in the stats</li>
+    <li>Enhancement: Avoid using experimental perl code.(i.e. ~~ )</li>
+    <li>Enhancement: restructure to make epm deployment easier</li>
+    <li>Enhancement: tooltip help text for KeyFigures</li>
+    <li>Enhancement: Optimisation for innodb</li>
+    <li>Enhancement: CSV, JSON, XML saves file as instead of open directly in the browser</li>
+    <li>Enhancement: Added missing libraries check (Date::Calc and Geo::IP) on bazzar installation page. resolves #10</li>
+    <li>Bugfix: Stats::View::google::Graph lose first statistics #69</li>
+    <li>Bugfix for Browser identification issue #66. Browser ID should be further improved</li>
+  </ul>
+
+  Merged pull requests:
+  <ul>
+    <li>Enhancement: %IGNORE_LIST of words (stopwords) are very few and only in "en"</li>
+    <li>Enhancement: Add support for transactions</li>
+    <li>Bugfix: The title of Screen::IRStats2::Report  should not change according to report you chose</li>
+    <li>Bugfix: Avoid XSS vulnerability in some CGI output</li>
+  </ul>
+</p>
+
+      </section>
+    </div>
+
+    <!-- FOOTER  -->
+    <div id="footer_wrap" class="outer">
+      <footer class="inner">
+        <p class="copyright">IRStats2 maintained by <a href="https://github.com/eprints">EPrints</a></p>
+        <p>Published with <a href="http://pages.github.com">GitHub Pages</a></p>
+      </footer>
+    </div>
+
+  </body>
+</html>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,8 @@
   <strong>What's new in version 1.1?</strong><br>
   This new version includes a number of improvements to existing features such as easier deployment, faster database code, 
   tool tips and improved browser detection, as well as a number of smaller tweaks and fixes.<br>
-  It now also includes filtering to allow the blocking of web crawling robots as standard.
+  It now also includes filtering to allow the blocking of web crawling robots as standard.<br>
+  See <a href="changes.html">here</a> for more details.
 </p>
   
 <p>Please read along to find out how to get it and how to customise it.</p>

--- a/index.html
+++ b/index.html
@@ -38,6 +38,13 @@
 
 <p>IRStats2 is developed against EPrints 3.3 but it was written to also work on EPrints 3.2. Older versions of EPrints are, however, not supported.</p>
 
+<p>
+  <b>What's new in version 1.1?</b><br>
+  The new version includes a number of improvements to existing features such as easier deployment, faster database code, 
+  tool tips and improved browser detection, as well as a number of smaller tweaks and fixes.<br>
+  It now also includes filtering to allow the blocking of web crawling robots as standard.
+</p>
+  
 <p>Please read along to find out how to get it and how to customise it.</p>
 
 <ul>

--- a/index.html
+++ b/index.html
@@ -34,13 +34,16 @@
     <div id="main_content_wrap" class="outer">
       <section id="main_content" class="inner">
 
-<p>IRStats2 is a statistical framework for EPrints - It comes with some cool default tools and reports and it can also be customised to, for instance, add new metrics or data sets. It has a Javascript API to include stats on any pages you want.</p>
+<p>
+  <strong>What is IRStats2?</strong>
+  IRStats2 is a statistical framework for EPrints - It comes with some cool default tools and reports and it can also be customised to, for instance, add new metrics or data sets. It has a Javascript API to include stats on any pages you want.
+</p>
 
 <p>IRStats2 is developed against EPrints 3.3 but it was written to also work on EPrints 3.2. Older versions of EPrints are, however, not supported.</p>
 
 <p>
-  <b>What's new in version 1.1?</b><br>
-  The new version includes a number of improvements to existing features such as easier deployment, faster database code, 
+  <strong>What's new in version 1.1?</strong><br>
+  This new version includes a number of improvements to existing features such as easier deployment, faster database code, 
   tool tips and improved browser detection, as well as a number of smaller tweaks and fixes.<br>
   It now also includes filtering to allow the blocking of web crawling robots as standard.
 </p>

--- a/index.html
+++ b/index.html
@@ -35,7 +35,7 @@
       <section id="main_content" class="inner">
 
 <p>
-  <strong>What is IRStats2?</strong>
+  <strong>What is IRStats2?</strong><br>
   IRStats2 is a statistical framework for EPrints - It comes with some cool default tools and reports and it can also be customised to, for instance, add new metrics or data sets. It has a Javascript API to include stats on any pages you want.
 </p>
 


### PR DESCRIPTION
It would be nice to have GH pages enabled for this repository so people can stop going to the original repos page then being sent to the wrong bugtracker (eprints/irstats2).
This updates the gh-pages branch so it can be used for that purpose.