### PR TITLE
Add StaticContent view

### DIFF
--- a/cfg.d/z_irstats2.pl
+++ b/cfg.d/z_irstats2.pl
@@ -528,6 +528,7 @@ $c->{plugins}{"Stats::View::Google::Spark"}{params}{disable} = 0;
 $c->{plugins}{"Stats::View::Grid"}{params}{disable} = 0;
 $c->{plugins}{"Stats::View::KeyFigures"}{params}{disable} = 0;
 $c->{plugins}{"Stats::View::ReportHeader"}{params}{disable} = 0;
+$c->{plugins}{"Stats::View::StaticContent"}{params}{disable} = 0;
 $c->{plugins}{"Stats::View::Table"}{params}{disable} = 0;
 
 $c->{plugins}{"Stats::View::D3::Graph"}{params}{disable} = 0;

--- a/cfg.d/z_irstats2.pl
+++ b/cfg.d/z_irstats2.pl
@@ -11,7 +11,7 @@ $c->{irstats2}->{datasets} = {
 
 	eprint => { incremental => 0 },
 	
-	access => { filters => [ 'Robots', 'Repeat'] },
+	access => { filters => [ 'BadAccessData', 'Robots', 'Repeat'] },
 
 	history => { incremental => 1 },
 
@@ -501,6 +501,7 @@ $c->{plugins}{"Stats::Filter::Robots"}{params}{disable} = 0;
 $c->{plugins}{"Stats::Filter::Repeat"}{params}{disable} = 0;
 #MM 04/05/2017 - New filter for IP addresses
 $c->{plugins}{"Stats::Filter::LocalIP"}{params}{disable} = 0;
+$c->{plugins}{"Stats::Filter::BadAccessData"}{params}{disable} = 0;
 
 
 $c->{plugins}{"Stats::Processor::Access"}{params}{disable} = 0;

--- a/plugins/EPrints/Plugin/Stats/Filter/BadAccessData.pm
+++ b/plugins/EPrints/Plugin/Stats/Filter/BadAccessData.pm
@@ -1,0 +1,53 @@
+package EPrints::Plugin::Stats::Filter::BadAccessData;
+
+use EPrints::Plugin::Stats::Processor;
+
+our @ISA = qw/ EPrints::Plugin::Stats::Processor /;
+
+use strict;
+
+# Stats::Filter::BadAccessData
+#
+# Filters out rows which failed to savein the database. These will have only an accessid, but no other data.
+#
+
+sub new
+{
+        my( $class, %params ) = @_;
+	my $self = $class->SUPER::new( %params );
+
+        $self->{provides} = [];
+
+        $self->{disable} = 0;
+	$self->{priority} = 100;
+
+	return $self;
+}
+
+sub create_tables 
+{
+        my( $self, $handler ) = @_;
+}
+
+sub clear_cache
+{
+        my( $self ) = @_;
+}
+
+sub commit_data
+{
+        my( $self, $handler ) = @_;
+}
+
+# if datstamp isn't set, it's a bad row!
+sub filter_record
+{
+	my ($self, $record) = @_;
+
+	return 1 unless defined $record->{datestamp};
+
+	return 0;
+
+}
+
+1;

--- a/plugins/EPrints/Plugin/Stats/Processor/Access.pm
+++ b/plugins/EPrints/Plugin/Stats/Processor/Access.pm
@@ -298,16 +298,22 @@ sub transform
 		referent_docid => $row->[12],
 	};
 
-	my $hour = sprintf( "%02d", $row->[4] );	
-	my $day = sprintf( "%02d", $row->[3]);
-	my $month = sprintf( "%02d", $row->[2]);
+	# Deal with bad data. If an access has failed to store in the DB, the row will have an acecssid but no other data.
+	# The 'filters' are applied after this transform has taken place.
+	# If we just returned undef from this method, it would exit the processing loop too early.
 	my $year = $row->[1];
+	if( defined $year )
+	{
+		my $hour = sprintf( "%02d", $row->[4] );	
+		my $day = sprintf( "%02d", $row->[3] );
+		my $month = sprintf( "%02d", $row->[2] );
 
-	$h->{datestamp} = {
-		hour => $hour, day => $day, month => $month, year => $year,
-		cache => "$year$month$day",
-		epoch => timegm_nocheck $row->[6]||0,$row->[5]||0,$row->[4],$row->[3],$row->[2]-1,$row->[1]-1900,
-	};
+		$h->{datestamp} = {
+			hour => $hour, day => $day, month => $month, year => $year,
+			cache => "$year$month$day",
+			epoch => timegm_nocheck $row->[6]||0,$row->[5]||0,$row->[4],$row->[3],$row->[2]-1,$row->[1]-1900,
+		};
+	}
 
 	$self->{last_record} = $h;
 

--- a/plugins/EPrints/Plugin/Stats/Utils.pm
+++ b/plugins/EPrints/Plugin/Stats/Utils.pm
@@ -55,6 +55,10 @@ sub validate_non_context_param
         {
                 return $v =~ /^\d+|all$/;
         }
+        elsif( $k eq 'fields' )
+        {
+                return $v =~ /^value|datestamp|eprintid|set_value$/;
+        }
         elsif( $k eq 'date_resolution' )
         {
                 return $v =~ /^day|month|year$/;
@@ -77,6 +81,10 @@ sub validate_non_context_param
 		# https://perldoc.perl.org/perlrecharclass#Bracketed-Character-Classes
 		return $v =~ /^[[:print:]]+$/;
 	}
+        elsif( $k =~ /^do_render|human_display|show_count|show_more|show_order$/ )
+        {
+                return $v =~ /^0|1$/; 
+        }
         elsif( $k =~ /^export|top|view|container_id$/ )
         {
                 return $v =~ /^[\w\.\-\:]+$/; #NB \w includes underscore, digit

--- a/plugins/EPrints/Plugin/Stats/View/StaticContent.pm
+++ b/plugins/EPrints/Plugin/Stats/View/StaticContent.pm
@@ -1,0 +1,97 @@
+package EPrints::Plugin::Stats::View::StaticContent;
+
+use EPrints::Plugin::Stats::View;
+@ISA = ('EPrints::Plugin::Stats::View');
+
+use strict;
+
+# Stats::View::StaticContent
+#
+# Allows phrases to be embeded in the Stats grid layout.
+# Phrases can contain script references/blocks, so this View can be used to do a lot - if you
+# make your phrases complicated enough!
+#
+# Options:
+# - title_phrase
+# - view
+# - page_phrase
+# - container_class (can be used to remove box outlines)
+# - title_class
+# - content_class
+
+sub can_export { return 0; }
+
+sub has_title
+{
+	my( $self ) = @_;
+
+	return defined $self->options->{title_phrase};
+}
+
+# Mostly the same as Stats::View, but with the ability to not have a border around everything
+sub render
+{
+	my( $self ) = @_;
+
+	my $session = $self->{session};
+	my $frag = $session->make_doc_fragment;
+	my $options = $self->options;
+
+	# just re-use $self->options->{view}
+	my $class_id = $self->get_id;
+	$class_id =~ s/^Stats::View:://g;
+	$class_id =~ s/::/_/g;
+
+	my $classes = "irstats2_view irstats2_view_$class_id";
+	$classes .= " $options->{container_class}" if defined $options->{container_class};
+
+	if( $self->{hide_from_print} )
+	{
+		$classes .= " ep_noprint";
+	}
+
+	my $container = $session->make_element( 'div', class => "$classes" );
+	$frag->appendChild( $container );
+
+	if( $self->has_title() )
+	{
+		my $title_class = 'irstats2_view_title';
+		$title_class .= " $options->{title_class}" if defined $options->{title_class};
+		my $title = $session->make_element( "div", class => $title_class );
+
+		$title->appendChild( $self->html_phrase( $options->{title_phrase} ) );
+
+		$container->appendChild( $title );
+	}
+
+	my $content_class = "irstats2_view_content";
+	$content_class .= " $options->{content_class}" if defined $options->{content_class};
+
+	my $content = $session->make_element( "div", class => $content_class );
+	$container->appendChild( $content );
+
+	$content->appendChild( $self->render_content() );
+
+	return $frag;
+}
+
+sub render_content
+{
+	my( $self ) = @_;
+
+	my $session = $self->{session};
+
+	my $frag = $session->make_doc_fragment;
+	my $view = $self->options->{view};
+	my $page = $self->options->{page_phrase};
+
+	$frag->appendChild( $self->html_phrase( $page ) );
+
+	return $frag;
+}
+
+# Renders the title of the View, if any.
+sub render_title { shift->html_phrase( 'title' ) }
+
+1;
+


### PR DESCRIPTION
Renders a panel, with or without a frame with content and optional title defined by phrases.

An example item in a view would be:
```perl
{
    plugin => 'StaticContent',
    options => {
        page_phrase => 'main_report_page',
        # following are all optional
        title_phrase => 'main_report_title',
        container_class => 'flibble',            
        title_class => 'wibble',
        content_class => 'dodah',
    },
},
```